### PR TITLE
Fixed THOUSAND_SEPARATOR for locale es_MX

### DIFF
--- a/django/conf/locale/es_MX/formats.py
+++ b/django/conf/locale/es_MX/formats.py
@@ -21,5 +21,5 @@ DATETIME_INPUT_FORMATS = [
     '%d/%m/%y %H:%M',
 ]
 DECIMAL_SEPARATOR = '.'   # ',' is also official (less common): NOM-008-SCFI-2002
-THOUSAND_SEPARATOR = '\xa0'  # non-breaking space
+THOUSAND_SEPARATOR = ','
 NUMBER_GROUPING = 3


### PR DESCRIPTION
Added ', ' and removed '\xa0'